### PR TITLE
docs(README): use latest release for download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 brew install only-switch
 ```
 ## Manually Download
-[**Download the app**](https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.4.2/OnlySwitch.dmg)
+[**Download the app**](https://github.com/jacklandrin/OnlySwitch/releases/latest/download/OnlySwitch.dmg)
 
 ## Communities
 Telegram group: https://t.me/OnlySwitchforMac


### PR DESCRIPTION
When releasing a new version, it appears you have to manually change the download link in the README.

Let's make your life easier and use the link for the latest release :-) .
