### PR TITLE
feat: sync external monitor brightness via DDC/CI (F1/F2 follows on all displays)

### DIFF
--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -4,6 +4,12 @@
     "External Displays" : {
       "extractionState" : "manual",
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externí displeje"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15,12 +21,114 @@
             "state" : "translated",
             "value" : "External Displays"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantallas externas"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mga External na Display"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrans externes"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vanjski zasloni"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display esterni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部ディスプレイ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "외부 디스플레이"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe schermen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyświetlacze zewnętrzne"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitores externos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Внешние дисплеи"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externé displeje"
+          }
+        },
+        "so" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Muuqaallada dibadda"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harici Ekranlar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зовнішні дисплеї"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外接显示器"
+          }
         }
       }
     },
     "External monitors follow the built-in display's brightness (F1/F2) via DDC/CI." : {
       "extractionState" : "manual",
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externí monitory sledují jas vestavěného displeje (F1/F2) přes DDC/CI."
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32,12 +140,114 @@
             "state" : "translated",
             "value" : "External monitors follow the built-in display's brightness (F1/F2) via DDC/CI."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los monitores externos siguen el brillo de la pantalla integrada (F1/F2) mediante DDC/CI."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sinusunod ng mga external na monitor ang liwanag ng built-in na display (F1/F2) sa pamamagitan ng DDC/CI."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les moniteurs externes suivent la luminosité de l'écran intégré (F1/F2) via DDC/CI."
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vanjski monitori prate svjetlinu ugrađenog zaslona (F1/F2) putem DDC/CI-ja."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I monitor esterni seguono la luminosità del display integrato (F1/F2) tramite DDC/CI."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部モニターが内蔵ディスプレイの明るさ（F1/F2）にDDC/CI経由で追従します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "외부 모니터가 내장 디스플레이 밝기(F1/F2)를 DDC/CI로 따라갑니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe monitoren volgen de helderheid van het ingebouwde scherm (F1/F2) via DDC/CI."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitory zewnętrzne podążają za jasnością wbudowanego wyświetlacza (F1/F2) przez DDC/CI."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os monitores externos acompanham o brilho da tela integrada (F1/F2) via DDC/CI."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Внешние мониторы следуют за яркостью встроенного дисплея (F1/F2) через DDC/CI."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externé monitory sledujú jas vstavaného displeja (F1/F2) cez DDC/CI."
+          }
+        },
+        "so" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kormeeryaha dibadda waxay raacaan iftiinka muuqaalka gudaha (F1/F2) iyada oo loo marayo DDC/CI."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harici monitörler dahili ekranın parlaklığını (F1/F2) DDC/CI üzerinden takip eder."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зовнішні монітори повторюють яскравість вбудованого дисплея (F1/F2) через DDC/CI."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外接显示器通过 DDC/CI 跟随内置显示屏的亮度（F1/F2）。"
+          }
         }
       }
     },
     "Sync external monitors" : {
       "extractionState" : "manual",
       "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizovat externí monitory"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48,6 +258,102 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sync external monitors"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar monitores externos"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "I-sync ang mga external na monitor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchroniser les moniteurs externes"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sinkroniziraj vanjske monitore"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizza i monitor esterni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部モニターを同期"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "외부 모니터 동기화"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe monitoren synchroniseren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizuj monitory zewnętrzne"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar monitores externos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать внешние мониторы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizovať externé monitory"
+          }
+        },
+        "so" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Isku-xir kormeeryaha dibadda"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harici monitörleri eşitle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронізувати зовнішні монітори"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步外接显示器"
           }
         }
       }

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -1,6 +1,57 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "External Displays" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe Bildschirme"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External Displays"
+          }
+        }
+      }
+    },
+    "External monitors follow the built-in display's brightness (F1/F2) via DDC/CI." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe Monitore folgen der Helligkeit des eingebauten Bildschirms (F1/F2) per DDC/CI."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "External monitors follow the built-in display's brightness (F1/F2) via DDC/CI."
+          }
+        }
+      }
+    },
+    "Sync external monitors" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Externe Monitore synchronisieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync external monitors"
+          }
+        }
+      }
+    },
     "" : {
       "localizations" : {
         "cs" : {

--- a/Modules/Sources/Defines/NotificationNames.swift
+++ b/Modules/Sources/Defines/NotificationNames.swift
@@ -28,6 +28,7 @@ public extension Notification.Name {
     static let changeAutoStopNoiseTime = Notification.Name(rawValue: "changeAutoStopNoiseTime")
     static let changeKeepAwakeSetting = Notification.Name(rawValue: "changeKeepAwakeSetting")
     static let changeDimScreenSetting = Notification.Name(rawValue: "changeDimScreenSetting")
+    static let changeSyncExternalBrightnessSetting = Notification.Name(rawValue: "changeSyncExternalBrightnessSetting")
     static let changeNightShiftSetting = Notification.Name(rawValue: "changeNightShiftSetting")
     static let toggleSplitSettingsWindow = Notification.Name(rawValue: "toggleSplitSettingsWindow")
 }

--- a/Modules/Sources/Extensions/UserDefaultsKeys.swift
+++ b/Modules/Sources/Extensions/UserDefaultsKeys.swift
@@ -55,6 +55,7 @@ public extension UserDefaults {
         //Dim Screen
         public static let autoDimScreenTime = "autoDimScreenTimeKey"
         public static let dimScreenPercent = "dimScreenPercentKey"
+        public static let syncExternalBrightness = "syncExternalBrightnessKey"
         //Night Shift
         public static let nightShiftStrength = "nightShiftStrengthKey"
         public static let nightShiftStartDate = "nightShiftStartDateKey"

--- a/OnlySwitch.xcodeproj/project.pbxproj
+++ b/OnlySwitch.xcodeproj/project.pbxproj
@@ -213,6 +213,9 @@
 		047F3A38285DE67A004FFCDF /* SwitchListApperanceDefine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F3A36285DE67A004FFCDF /* SwitchListApperanceDefine.swift */; };
 		04819CD22BBC884A00645A0C /* BrightnessControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 04819CCF2BBC884900645A0C /* BrightnessControl.m */; };
 		04819CD32BBC884A00645A0C /* KeyboardManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 04819CD12BBC884A00645A0C /* KeyboardManager.m */; };
+		0DDC000000000000000000B2 /* DDCControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DDC000000000000000000A2 /* DDCControl.m */; };
+		0DDC000000000000000000B3 /* ExternalDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDC000000000000000000A3 /* ExternalDisplayManager.swift */; };
+		0DDC000000000000000000B4 /* BrightnessSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDC000000000000000000A4 /* BrightnessSyncManager.swift */; };
 		04819CD52BBC8A6700645A0C /* KeyLightSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04819CD42BBC8A6700645A0C /* KeyLightSwitch.swift */; };
 		04819CD82BBC957D00645A0C /* KeyLightView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04819CD72BBC957D00645A0C /* KeyLightView.swift */; };
 		04819CDA2BDE9BFA00645A0C /* KeyLightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04819CD92BDE9BFA00645A0C /* KeyLightFeature.swift */; };
@@ -546,6 +549,10 @@
 		04819CCF2BBC884900645A0C /* BrightnessControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrightnessControl.m; sourceTree = "<group>"; };
 		04819CD02BBC884900645A0C /* KeyboardManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardManager.h; sourceTree = "<group>"; };
 		04819CD12BBC884A00645A0C /* KeyboardManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyboardManager.m; sourceTree = "<group>"; };
+		0DDC000000000000000000A1 /* DDCControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDCControl.h; sourceTree = "<group>"; };
+		0DDC000000000000000000A2 /* DDCControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDCControl.m; sourceTree = "<group>"; };
+		0DDC000000000000000000A3 /* ExternalDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalDisplayManager.swift; sourceTree = "<group>"; };
+		0DDC000000000000000000A4 /* BrightnessSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessSyncManager.swift; sourceTree = "<group>"; };
 		04819CD42BBC8A6700645A0C /* KeyLightSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLightSwitch.swift; sourceTree = "<group>"; };
 		04819CD72BBC957D00645A0C /* KeyLightView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLightView.swift; sourceTree = "<group>"; };
 		04819CD92BDE9BFA00645A0C /* KeyLightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLightFeature.swift; sourceTree = "<group>"; };
@@ -1191,6 +1198,17 @@
 			path = KeyboardBrightness;
 			sourceTree = "<group>";
 		};
+		0DDC000000000000000000C1 /* DDC */ = {
+			isa = PBXGroup;
+			children = (
+				0DDC000000000000000000A1 /* DDCControl.h */,
+				0DDC000000000000000000A2 /* DDCControl.m */,
+				0DDC000000000000000000A3 /* ExternalDisplayManager.swift */,
+				0DDC000000000000000000A4 /* BrightnessSyncManager.swift */,
+			);
+			path = DDC;
+			sourceTree = "<group>";
+		};
 		04819CD62BBC954C00645A0C /* KeyLight */ = {
 			isa = PBXGroup;
 			children = (
@@ -1587,6 +1605,7 @@
 			isa = PBXGroup;
 			children = (
 				04819CCC2BBC881E00645A0C /* KeyboardBrightness */,
+				0DDC000000000000000000C1 /* DDC */,
 				040E97262760FF3E003D9D42 /* MetadataExtractorError.swift */,
 				04E03AFD275EA4EF00EA5FB9 /* BluetoothDevicesManager.swift */,
 				0427B25A275D786400AD783A /* SystemInfo.swift */,
@@ -2078,6 +2097,9 @@
 				04DC6CA028A7D52300888BF9 /* DimScreenSettingView.swift in Sources */,
 				04938D1027692B6900713F1D /* SwitchManager.swift in Sources */,
 				04819CD22BBC884A00645A0C /* BrightnessControl.m in Sources */,
+				0DDC000000000000000000B2 /* DDCControl.m in Sources */,
+				0DDC000000000000000000B3 /* ExternalDisplayManager.swift in Sources */,
+				0DDC000000000000000000B4 /* BrightnessSyncManager.swift in Sources */,
 				0493374527625A1E00AE779A /* JLASAudioPlayer.swift in Sources */,
 				0447E36D2B71746E00D07B9A /* NightShiftSwitch.swift in Sources */,
 				04CB89F72B6FFA65006B8620 /* ViewModify.swift in Sources */,

--- a/OnlySwitch/AppDelegate.swift
+++ b/OnlySwitch/AppDelegate.swift
@@ -195,6 +195,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Bundle.setLanguage(lang: LanguageManager.sharedManager.currentLang)
 
         registerShortcut()
+
+        // Mirror built-in display brightness to external monitors (issue #206) –
+        // start now if enabled and react to the setting being toggled later.
+        BrightnessSyncManager.shared.updateState()
+        NotificationCenter.default.addObserver(
+            forName: .changeSyncExternalBrightnessSetting,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                BrightnessSyncManager.shared.updateState()
+            }
+        }
+
         if PreferencesObserver.shared.preferences.checkUpdateOnLaunch {
             checkUpdate()
         }

--- a/OnlySwitch/Features/Settings/DimScreen/DimScreenSettingVM.swift
+++ b/OnlySwitch/Features/Settings/DimScreen/DimScreenSettingVM.swift
@@ -36,6 +36,15 @@ class DimScreenSettingVM: ObservableObject {
             preferences.autoDimScreenTime = newValue
         }
     }
+
+    var syncExternalBrightness:Bool {
+        get {
+            preferences.syncExternalBrightness
+        }
+        set {
+            preferences.syncExternalBrightness = newValue
+        }
+    }
     
     func converTimeDescription(duration:Int) -> String {
         if duration == 0 {

--- a/OnlySwitch/Features/Settings/DimScreen/DimScreenSettingView.swift
+++ b/OnlySwitch/Features/Settings/DimScreen/DimScreenSettingView.swift
@@ -32,6 +32,20 @@ struct DimScreenSettingView: View {
             } header: {
                 Text("Brightness".localized())
             }
+
+            // MARK: - External Displays Section
+            Section {
+                Toggle(isOn: $vm.syncExternalBrightness) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Sync external monitors".localized())
+                        Text("External monitors follow the built-in display's brightness (F1/F2) via DDC/CI.".localized())
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            } header: {
+                Text("External Displays".localized())
+            }
         }
         .formStyle(.grouped)
     }

--- a/OnlySwitch/Header/OnlySwitch-Bridging-Header.h
+++ b/OnlySwitch/Header/OnlySwitch-Bridging-Header.h
@@ -9,6 +9,7 @@
 #import "CBTrueToneClient.h"
 #import "BrightnessControl.h"
 #import "KeyboardManager.h"
+#import "DDCControl.h"
 #import <Foundation/Foundation.h>
 #import <IOKit/i2c/IOI2CInterface.h>
 #import <CoreGraphics/CoreGraphics.h>

--- a/OnlySwitch/Model/Preferences.swift
+++ b/OnlySwitch/Model/Preferences.swift
@@ -201,6 +201,15 @@ final class Preferences: @unchecked Sendable {
         }
     }
 
+    /// When on, external monitors follow the built-in display's brightness
+    /// (F1/F2, Control Center, Dim Screen, …) over DDC/CI.
+    @UserDefaultValue(key: UserDefaults.Key.syncExternalBrightness, defaultValue: false)
+    var syncExternalBrightness:Bool {
+        didSet {
+            NotificationCenter.default.post(name: .changeSyncExternalBrightnessSetting, object: nil)
+        }
+    }
+
     // MARK: - Night Shift
     @UserDefaultValue(key: UserDefaults.Key.nightShiftStrength, defaultValue: 0.5)
     var nightShiftStrength: Float {

--- a/OnlySwitch/Utilities/DDC/BrightnessSyncManager.swift
+++ b/OnlySwitch/Utilities/DDC/BrightnessSyncManager.swift
@@ -1,0 +1,118 @@
+//
+//  BrightnessSyncManager.swift
+//  OnlySwitch
+//
+//  Keeps external monitors in lock-step with the built-in display's brightness.
+//
+//  macOS only routes the F1/F2 brightness keys – and the ambient-light sensor,
+//  Control Center slider, the Dim Screen switch, etc. – to the built-in panel.
+//  We poll the built-in brightness and, whenever it moves, push the same 0...1
+//  level to every external display over DDC/CI. So dimming the built-in screen
+//  dims all connected monitors to the same level automatically. At the built-in
+//  panel's minimum the external monitors are switched fully off (DPMS) so they go
+//  dark together, and powered back on as soon as the brightness rises again.
+//
+
+import Foundation
+import AppKit
+import Combine
+
+@MainActor
+final class BrightnessSyncManager {
+    static let shared = BrightnessSyncManager()
+
+    private let displayManager = DisplayManager()
+    private var timerCancellable: AnyCancellable?
+    private var lastSyncedBrightness: Float = -1
+    private var externalsPoweredOff = false
+    private var isRunning = false
+
+    /// Smallest built-in brightness change worth mirroring (~0.4%). Filters out
+    /// floating-point noise while still catching a single F1/F2 key press.
+    private let changeThreshold: Float = 0.004
+
+    /// At/below this built-in level the external monitors are switched fully off
+    /// via DDC power control (DPMS), so they go dark together with the built-in
+    /// panel at its minimum instead of staying on at their lowest backlight.
+    private let powerOffThreshold: Float = 0.01
+
+    private init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(screenParametersChanged),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    /// Starts or stops syncing according to the user's preference.
+    func updateState() {
+        if Preferences.shared.syncExternalBrightness {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    private func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        lastSyncedBrightness = -1
+        ExternalDisplayManager.shared.refresh()
+        timerCancellable = Timer.publish(every: 0.5, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.syncIfNeeded()
+            }
+    }
+
+    private func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        timerCancellable?.cancel()
+        timerCancellable = nil
+        // Don't leave external monitors stuck in DPMS off when syncing is disabled.
+        if externalsPoweredOff {
+            externalsPoweredOff = false
+            ExternalDisplayManager.shared.setPower(on: true)
+        }
+    }
+
+    private func syncIfNeeded() {
+        displayManager.configureDisplays()
+        guard displayManager.existBuiltInDisplay else { return }
+
+        let brightness = displayManager.getBrightness()
+
+        // Built-in at its minimum: switch the external monitors fully off.
+        if brightness <= powerOffThreshold {
+            if !externalsPoweredOff {
+                externalsPoweredOff = true
+                lastSyncedBrightness = brightness
+                ExternalDisplayManager.shared.setPower(on: false)
+            }
+            return
+        }
+
+        // Coming back up from off: power the monitors on, then mirror brightness
+        // on the next tick once they have woken.
+        if externalsPoweredOff {
+            externalsPoweredOff = false
+            lastSyncedBrightness = -1
+            ExternalDisplayManager.shared.setPower(on: true)
+            return
+        }
+
+        guard abs(brightness - lastSyncedBrightness) > changeThreshold else { return }
+        lastSyncedBrightness = brightness
+        ExternalDisplayManager.shared.setBrightness(percentage: brightness)
+    }
+
+    @objc private func screenParametersChanged() {
+        guard isRunning else { return }
+        // A monitor was (dis)connected – rebuild the DDC cache and re-mirror.
+        lastSyncedBrightness = -1
+        externalsPoweredOff = false
+        ExternalDisplayManager.shared.refresh()
+    }
+}

--- a/OnlySwitch/Utilities/DDC/DDCControl.h
+++ b/OnlySwitch/Utilities/DDC/DDCControl.h
@@ -1,0 +1,48 @@
+//
+//  DDCControl.h
+//  OnlySwitch
+//
+//  Talks DDC/CI to external displays so their brightness can follow the
+//  built-in screen. Uses the private `IOAVService` API on Apple Silicon –
+//  the same approach used by MonitorControl and waydabber/m1ddc.
+//
+
+#ifndef DDCControl_h
+#define DDCControl_h
+
+#import <Foundation/Foundation.h>
+#import <IOKit/IOKitLib.h>
+
+/// `IOAVService` is a private CoreFoundation type. Its symbols are exported by
+/// IOKit, so we only need to forward declare them here.
+typedef CFTypeRef IOAVServiceRef;
+
+extern IOAVServiceRef IOAVServiceCreate(CFAllocatorRef allocator);
+extern IOAVServiceRef IOAVServiceCreateWithService(CFAllocatorRef allocator, io_service_t service);
+extern IOReturn IOAVServiceReadI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t offset, void *outputBuffer, uint32_t outputBufferSize);
+extern IOReturn IOAVServiceWriteI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t dataAddress, void *inputBuffer, uint32_t inputBufferSize);
+
+/// Thin wrapper around DDC/CI brightness control for every connected external
+/// monitor. All methods touch the I2C bus and are therefore slow (tens of
+/// milliseconds per display) – call them from a background queue.
+@interface DDCControl : NSObject
+
+/// Rediscovers the connected external (DDC/CI capable) displays and caches each
+/// one's maximum brightness value. Call once before adjusting brightness and
+/// again whenever the screen arrangement changes.
++ (void)refreshExternalDisplays;
+
+/// Number of external displays found by the last `refreshExternalDisplays` call.
++ (NSInteger)externalDisplayCount;
+
+/// Sets every cached external display to `percentage` (0.0 – 1.0) of its own
+/// maximum brightness.
++ (void)setExternalBrightnessPercentage:(float)percentage;
+
+/// Powers every cached external display on (`YES`) or into DPMS off (`NO`) via
+/// the VCP power-mode feature, so they can go fully dark with the built-in panel.
++ (void)setExternalDisplaysPower:(BOOL)on;
+
+@end
+
+#endif /* DDCControl_h */

--- a/OnlySwitch/Utilities/DDC/DDCControl.m
+++ b/OnlySwitch/Utilities/DDC/DDCControl.m
@@ -6,6 +6,7 @@
 #import "DDCControl.h"
 #import <unistd.h>
 #import <math.h>
+#import <string.h>
 @import IOKit;
 
 // DDC/CI over I2C constants (VESA MCCS). Values mirror waydabber/m1ddc.

--- a/OnlySwitch/Utilities/DDC/DDCControl.m
+++ b/OnlySwitch/Utilities/DDC/DDCControl.m
@@ -1,0 +1,214 @@
+//
+//  DDCControl.m
+//  OnlySwitch
+//
+
+#import "DDCControl.h"
+#import <unistd.h>
+#import <math.h>
+@import IOKit;
+
+// DDC/CI over I2C constants (VESA MCCS). Values mirror waydabber/m1ddc.
+static const uint32_t  kDDCChipAddress     = 0x37;
+static const uint32_t  kDDCInputAddress    = 0x51;
+static const uint8_t   kVCPLuminance       = 0x10;   // VCP "Luminance" feature code
+static const uint8_t   kVCPPowerMode       = 0xD6;   // VCP "Power Mode" feature code
+static const uint16_t  kPowerModeOn        = 0x01;   // DPMS on
+static const uint16_t  kPowerModeOff       = 0x04;   // DPMS off (wakes again via DDC)
+static const useconds_t kDDCWaitMicros     = 10000;  // settle time between I2C transactions
+static const int       kDDCWriteIterations = 2;      // some displays need the write repeated
+
+#pragma mark - Cached display model
+
+@interface DDCDisplay : NSObject
+@property (nonatomic, strong) id avService; // IOAVServiceRef held by ARC
+@property (nonatomic, assign) int maxValue;
+@end
+
+@implementation DDCDisplay
+@end
+
+#pragma mark - DDCControl
+
+@implementation DDCControl
+
+static NSMutableArray<DDCDisplay *> *_displays;
+
+#pragma mark Low level I2C
+
++ (BOOL)sendBytes:(const uint8_t *)bytes
+           length:(uint32_t)length
+        toService:(IOAVServiceRef)service {
+    for (int i = 0; i < kDDCWriteIterations; i++) {
+        usleep(kDDCWaitMicros);
+        IOReturn result = IOAVServiceWriteI2C(service,
+                                              kDDCChipAddress,
+                                              kDDCInputAddress,
+                                              (void *)bytes,
+                                              length);
+        if (result != kIOReturnSuccess) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
++ (BOOL)writeVCPCode:(uint8_t)code value:(uint16_t)value toService:(IOAVServiceRef)service {
+    uint8_t data[6];
+    data[0] = 0x84;                  // length / op
+    data[1] = 0x03;                  // "Set VCP Feature"
+    data[2] = code;
+    data[3] = (value >> 8) & 0xFF;   // high byte
+    data[4] = value & 0xFF;          // low byte
+    data[5] = 0x6E ^ kDDCInputAddress ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4];
+    return [self sendBytes:data length:sizeof(data) toService:service];
+}
+
++ (BOOL)writeLuminance:(uint16_t)value toService:(IOAVServiceRef)service {
+    return [self writeVCPCode:kVCPLuminance value:value toService:service];
+}
+
++ (BOOL)readLuminanceFromService:(IOAVServiceRef)service
+                         current:(int *)current
+                             max:(int *)max {
+    uint8_t request[4];
+    request[0] = 0x82;               // length / op
+    request[1] = 0x01;               // "Get VCP Feature"
+    request[2] = kVCPLuminance;
+    request[3] = 0x6E ^ request[0] ^ request[1] ^ request[2];
+    if (![self sendBytes:request length:sizeof(request) toService:service]) {
+        return NO;
+    }
+
+    uint8_t reply[12] = {0};
+    usleep(kDDCWaitMicros);
+    if (IOAVServiceReadI2C(service,
+                           kDDCChipAddress,
+                           kDDCInputAddress,
+                           reply,
+                           sizeof(reply)) != kIOReturnSuccess) {
+        return NO;
+    }
+
+    // "Get VCP Feature Reply": maximum value in bytes [6..7], current value in
+    // bytes [8..9], both big-endian.
+    int maxValue = (reply[6] << 8) | reply[7];
+    int curValue = (reply[8] << 8) | reply[9];
+    // A real DDC brightness maximum is small – essentially always 100, never
+    // more than a couple hundred. Some displays return garbage on an unreliable
+    // read (seen: 0xC800 = 51200). If we cached that, brightness writes would be
+    // scaled to absurd 16-bit values and the monitor would flip between bright
+    // and dark. Reject implausible maxima so the caller keeps the safe default.
+    if (maxValue < 1 || maxValue > 255) {
+        return NO; // no/garbage response – treat as unreadable
+    }
+    if (max) { *max = maxValue; }
+    if (current) { *current = curValue; }
+    return YES;
+}
+
+#pragma mark Discovery
+
+/// Walks the IORegistry and returns an `IOAVService` for every external display.
+/// Built-in panels report a "Location" of "Embedded" and are skipped, so this
+/// only ever returns DDC/CI capable external monitors.
++ (NSArray<DDCDisplay *> *)discoverExternalDisplays {
+    NSMutableArray<DDCDisplay *> *result = [NSMutableArray array];
+
+    io_registry_entry_t root = IORegistryGetRootEntry(kIOMainPortDefault);
+    if (root == MACH_PORT_NULL) {
+        return result;
+    }
+
+    io_iterator_t iterator = MACH_PORT_NULL;
+    if (IORegistryEntryCreateIterator(root,
+                                      kIOServicePlane,
+                                      kIORegistryIterateRecursively,
+                                      &iterator) != KERN_SUCCESS) {
+        return result;
+    }
+
+    io_service_t service = MACH_PORT_NULL;
+    while ((service = IOIteratorNext(iterator)) != MACH_PORT_NULL) {
+        io_name_t name = {0};
+        if (IORegistryEntryGetName(service, name) == KERN_SUCCESS &&
+            strcmp(name, "DCPAVServiceProxy") == 0) {
+
+            CFTypeRef location = IORegistryEntrySearchCFProperty(service,
+                                                                 kIOServicePlane,
+                                                                 CFSTR("Location"),
+                                                                 kCFAllocatorDefault,
+                                                                 kIORegistryIterateRecursively);
+            BOOL isExternal = location != NULL &&
+                CFGetTypeID(location) == CFStringGetTypeID() &&
+                CFStringCompare((CFStringRef)location, CFSTR("External"), 0) == kCFCompareEqualTo;
+            if (location) {
+                CFRelease(location);
+            }
+
+            if (isExternal) {
+                IOAVServiceRef avService = IOAVServiceCreateWithService(kCFAllocatorDefault, service);
+                if (avService) {
+                    DDCDisplay *display = [DDCDisplay new];
+                    display.avService = (__bridge_transfer id)avService;
+                    display.maxValue = 100; // MCCS default until a read succeeds
+                    [result addObject:display];
+                }
+            }
+        }
+        IOObjectRelease(service);
+    }
+    IOObjectRelease(iterator);
+
+    return result;
+}
+
+#pragma mark Public API
+
++ (void)refreshExternalDisplays {
+    @synchronized (self) {
+        NSMutableArray<DDCDisplay *> *displays = [[self discoverExternalDisplays] mutableCopy];
+        for (DDCDisplay *display in displays) {
+            int maxValue = 0;
+            if ([self readLuminanceFromService:(__bridge IOAVServiceRef)display.avService
+                                       current:NULL
+                                           max:&maxValue]) {
+                display.maxValue = maxValue;
+            }
+        }
+        _displays = displays;
+    }
+}
+
++ (NSInteger)externalDisplayCount {
+    @synchronized (self) {
+        return (NSInteger)_displays.count;
+    }
+}
+
++ (void)setExternalBrightnessPercentage:(float)percentage {
+    @synchronized (self) {
+        if (_displays.count == 0) {
+            return;
+        }
+        float clamped = MAX(0.0f, MIN(1.0f, percentage));
+        for (DDCDisplay *display in _displays) {
+            uint16_t value = (uint16_t)lroundf(clamped * (float)display.maxValue);
+            [self writeLuminance:value toService:(__bridge IOAVServiceRef)display.avService];
+        }
+    }
+}
+
++ (void)setExternalDisplaysPower:(BOOL)on {
+    @synchronized (self) {
+        if (_displays.count == 0) {
+            return;
+        }
+        uint16_t value = on ? kPowerModeOn : kPowerModeOff;
+        for (DDCDisplay *display in _displays) {
+            [self writeVCPCode:kVCPPowerMode value:value toService:(__bridge IOAVServiceRef)display.avService];
+        }
+    }
+}
+
+@end

--- a/OnlySwitch/Utilities/DDC/ExternalDisplayManager.swift
+++ b/OnlySwitch/Utilities/DDC/ExternalDisplayManager.swift
@@ -1,0 +1,44 @@
+//
+//  ExternalDisplayManager.swift
+//  OnlySwitch
+//
+//  Funnels all DDC/CI traffic to external monitors through a single serial
+//  background queue (the I2C bus is slow and not thread-safe).
+//
+
+import Foundation
+
+final class ExternalDisplayManager: @unchecked Sendable {
+    static let shared = ExternalDisplayManager()
+
+    private let queue = DispatchQueue(label: "com.jacklandrin.OnlySwitch.ddc", qos: .userInitiated)
+
+    private init() {}
+
+    /// Rediscovers connected external displays. Call after the screen layout
+    /// changes. `completion` is delivered on the main queue with the new count.
+    func refresh(completion: (@Sendable (Int) -> Void)? = nil) {
+        queue.async {
+            DDCControl.refreshExternalDisplays()
+            let count = DDCControl.externalDisplayCount()
+            if let completion {
+                DispatchQueue.main.async { completion(count) }
+            }
+        }
+    }
+
+    /// Mirrors an absolute brightness (0...1) onto every external display.
+    func setBrightness(percentage: Float) {
+        let clamped = max(0, min(1, percentage))
+        queue.async {
+            DDCControl.setExternalBrightnessPercentage(clamped)
+        }
+    }
+
+    /// Powers every external display on, or into DPMS off so it goes fully dark.
+    func setPower(on: Bool) {
+        queue.async {
+            DDCControl.setExternalDisplaysPower(on)
+        }
+    }
+}


### PR DESCRIPTION
Closes #206 (and implements the request in #205).

### What
When OnlySwitch is running, external monitors now follow the built-in display's brightness. Today macOS only routes the F1/F2 brightness keys — and Control Center, the ambient-light sensor, the **Dim Screen** switch, etc. — to the built-in panel, so external displays stay put. With this change, dimming the built-in screen dims every connected monitor to the same level automatically.

It's an **opt-in** toggle **"Sync external monitors"** in *Settings → Dim Screen*. Off by default, so there is zero behavior change unless enabled.

### How
A single, uniform mechanism: poll the built-in brightness and, whenever it moves, mirror the same 0–1 level to every external display over DDC/CI. Because the Dim Screen switch also changes the built-in brightness, it's covered by the same path for free.

- **`DDCControl` (ObjC)** — talks DDC/CI over I2C using the private `IOAVService` API on Apple Silicon (the same approach as MonitorControl / m1ddc). Discovers external `DCPAVServiceProxy` services and writes the VCP *Luminance* (`0x10`) and *Power Mode* (`0xD6`) features. Implausible max-brightness readbacks (some displays return garbage, e.g. `0xC800`) are rejected so they can't poison the write scaling.
- **`ExternalDisplayManager`** — funnels all (slow) DDC traffic through one serial background queue.
- **`BrightnessSyncManager`** — polls built-in brightness, mirrors changes, and switches the external monitors fully off (DPMS) at the minimum so they go dark together with the built-in panel; powers them back on when brightness rises. Re-syncs on display (dis)connect.
- Localized in all shipped languages (fil/so flagged for native-speaker review).

### Notes / scope
- **Apple Silicon only.** On Intel Macs no external `IOAVService` is found, so it's a safe no-op. (The app is not sandboxed, so I2C/DDC access is available.)
- Brightness is mirrored as an absolute percentage — as with MonitorControl, "50%" on an external panel won't perfectly match the built-in panel's perceived brightness. A per-monitor offset could be a nice future addition but is out of scope here.
- Some monitors cut their DDC channel while off, so waking them from the minimum can take a moment — inherent to the display, not the code.

### Testing
Built and run on Apple Silicon (macOS) with two external monitors. Enabled the toggle, then verified F1/F2 and the Dim Screen switch both drive the external monitors in sync, and that they power off/on at the minimum. `xcodebuild` succeeds.