### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 # OnlySwitch
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/jacklandrin-onlyswitch)](https://takoapi.com/agents/jacklandrin-onlyswitch)
+
 ***Menubar is smaller, you only need an All-in-One switch.***
 
 ## Install by Homebrew


### PR DESCRIPTION
Hi! 👋 **OnlySwitch** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/jacklandrin-onlyswitch

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building OnlySwitch! 🙏