### PR TITLE
Fix Show List shortcut being treated as a right-click

### DIFF
--- a/Modules/Sources/Extensions/NSEvent++.swift
+++ b/Modules/Sources/Extensions/NSEvent++.swift
@@ -9,6 +9,6 @@ import AppKit
 
 public extension NSEvent {
     var isRightClicked: Bool {
-        type == .rightMouseDown || modifierFlags.contains(.control)
+        type == .rightMouseDown || (type == .leftMouseDown && modifierFlags.contains(.control))
     }
 }


### PR DESCRIPTION
Fixes #197.

The right-click helper treated any event containing the Control modifier as a right-click. As a result, a Control-based “Show List” keyboard shortcut entered the hidden-menu-icons branch instead of toggling the switch list.

Restrict Control-click detection to left mouse-down events while preserving native right mouse-down handling.

## Testing

- Confirmed the reported Control-Option-Command shortcut was classified as a right-click before the change and not afterward.
- Confirmed Control-click remains classified as a right-click.
- Built the affected `Extensions` scheme successfully on macOS 27.